### PR TITLE
Fix HTTP 414 error

### DIFF
--- a/main.py
+++ b/main.py
@@ -104,6 +104,7 @@ if __name__ == '__main__':
     elif arguments[1] == 'refresh':
       refresh = pt.refresh(*refresh_settings)
       print(refresh)
+
     elif arguments[1] == 'stash':
       stash = pt.stash(consumer_key, settings.pocket_access_token, archive_tag, settings.replace_all_tags, settings.retain_tags, settings.ignore_faves, settings.ignore_tags)
       print(stash)


### PR DESCRIPTION
When processing a List with a large number of items, an HTTP 414 error occurs due to the GET request URL being too long. This patch chunks tag update and item archiving API calls into groups of 20 items. Fixes #16 